### PR TITLE
Bugfix/trycast on revenue metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # dbt_shopify_holistic_reporting v0.1.1
-Bug Fixes
-Incorporate the try_cast macro from fivetran_utils to ensure that the numeric_value field in int__daily_klaviyo_user_metrics is the same data type as '0'. 
+## Bug Fixes
+Incorporate the try_cast macro from fivetran_utils to ensure that the numeric_value field in int__daily_klaviyo_user_metrics is the same data type as '0'. ([#6](https://github.com/fivetran/dbt_shopify_holistic_reporting/pull/6))
+
+## Contributors
+- [@MisterClean](https://github.com/MisterClean) ([#6](https://github.com/fivetran/dbt_shopify_holistic_reporting/pull/6))
 
 
 # dbt_shopify_holistic_reporting v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# dbt_shopify_holistic_reporting v0.1.1
+Bug Fixes
+Incorporate the try_cast macro from fivetran_utils to ensure that the numeric_value field in int__daily_klaviyo_user_metrics is the same data type as '0'. 
+
+
 # dbt_shopify_holistic_reporting v0.1.0
 
 The original release! This package currently models Shopify and Klaviyo data to achieve the following:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'shopify_holistic_reporting'
-version: '0.1.0'
+version: '0.1.1'
 config-version: 2
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'shopify_holistic_reporting_integration_tests'
-version: '0.1.0'
+version: '0.1.1'
 profile: 'integration_tests'
 config-version: 2
 

--- a/models/intermediate/int__daily_klaviyo_user_metrics.sql
+++ b/models/intermediate/int__daily_klaviyo_user_metrics.sql
@@ -21,7 +21,9 @@ with events as (
 
     -- sum up the numeric value associated with events (most likely will mean revenue)
     {% for rm in var('klaviyo__sum_revenue_metrics') %}
-    , sum(case when lower(type) = '{{ rm | lower }}' then numeric_value else 0 end) 
+    , sum(case when lower(type) = '{{ rm | lower }}' then 
+            coalesce({{ fivetran_utils.try_cast("numeric_value", "numeric") }}, 0)
+            else 0 end) 
         as {{ 'sum_revenue_' ~ rm | replace(' ', '_') | replace('(', '') | replace(')', '') | lower }} -- removing special characters that I have seen in different integration events
     {% endfor %}
 


### PR DESCRIPTION
Pull Request
**Are you a current Fivetran customer?** 
Yes, Copper Cow Coffee

**What change(s) does this PR introduce?** 
It's possible for the `numeric_value` field from Klaviyo to contain non-numeric data types, which leads this model to fail because the `sum_revenue_` field expects a numeric type. See #7 & [Issue17 in dbt_klaviyo](https://github.com/fivetran/dbt_klaviyo/issues/17) for more detail.

This {{ fivetran_utils.try_cast }} macro was recently implemented to solve this issue in the dbt_klaviyo package 0.4.1 release, and it solves the same issue here

**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Does this PR introduce a breaking change?**
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide an explanation as to how the change is non-breaking below.)


**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes, Issue/Feature # https://github.com/fivetran/dbt_klaviyo/issues/17
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [x] Local (please provide additional testing details below)

`dbt run --select int__daily_klaviyo_user_metrics+`

``` 
14:36:11  Found 219 models, 173 tests, 0 snapshots, 0 analyses, 774 macros, 0 operations, 0 seed files, 73 sources, 0 exposures, 0 metrics
14:36:12  Concurrency: 4 threads (target='default')
14:36:40  Finished running 1 view model, 1 table model in 29.37s.
14:36:40  Completed successfully
14:36:40  Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2
```


**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] BigQuery
- [ ] Redshift
- [ ] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:chart_with_upwards_trend:

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
